### PR TITLE
[BST-185]: Fixed the aria-roles and plugins preferences tab list structure.

### DIFF
--- a/webapp/channels/src/components/settings_sidebar/settings_sidebar.tsx
+++ b/webapp/channels/src/components/settings_sidebar/settings_sidebar.tsx
@@ -110,17 +110,31 @@ export default class SettingsSidebar extends React.PureComponent<Props> {
             pluginTabList = (
                 <>
                     <hr/>
-                    <li
-                        key={'plugin preferences heading'}
-                        role='heading'
-                        className={'header'}
+                    <div
+                        aria-labelledby={'userSettingsModal.pluginPreferences.header'}
+                        role='region'
                     >
-                        <FormattedMessage
+                        <div
                             id={'userSettingsModal.pluginPreferences.header'}
-                            defaultMessage={'PLUGIN PREFERENCES'}
-                        />
-                    </li>
-                    {this.props.pluginTabs.map((tab, index) => this.renderTab(tab, index))}
+                            key={'plugin preferences heading'}
+                            role='heading'
+                            aria-level={3}
+                            className={'header'}
+                        >
+                            <FormattedMessage
+                                id={'userSettingsModal.pluginPreferences.header'}
+                                defaultMessage={'PLUGIN PREFERENCES'}
+                            />
+                        </div>
+                        <ul
+                            id='tabList.plugins'
+                            className='nav nav-pills nav-stacked'
+                            role='tablist'
+                            aria-orientation='vertical'
+                        >
+                            {this.props.pluginTabs.map((tab, index) => this.renderTab(tab, index))}
+                        </ul>
+                    </div>
                 </>
             );
         }
@@ -134,8 +148,8 @@ export default class SettingsSidebar extends React.PureComponent<Props> {
                     aria-orientation='vertical'
                 >
                     {tabList}
-                    {pluginTabList}
                 </ul>
+                {pluginTabList}
             </div>
         );
     }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- Updated the Plugin preferences tab list structure in the user settings modal.
- Updated the aria-level and aria-role for the plugins preferences heading.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Jira https://brightscout.atlassian.net/jira/software/projects/BST/boards/27?selectedIssue=BST-185

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
