### PR TITLE
[MA-14]: Ensure all interactive functionality is operable with the keyboard in emoji picker

### DIFF
--- a/webapp/channels/src/components/emoji_picker/__snapshots__/emoji_picker.test.tsx.snap
+++ b/webapp/channels/src/components/emoji_picker/__snapshots__/emoji_picker.test.tsx.snap
@@ -134,7 +134,9 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
       style="height: 290px;"
     >
       <div
+        aria-labelledby="emojiPickerSearch"
         class="emoji-picker__container"
+        role="grid"
       >
         <div
           style="overflow: visible; height: 0px; width: 0px;"

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_category_or_emoji_row.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_category_or_emoji_row.tsx
@@ -35,6 +35,7 @@ function EmojiPickerCategoryOrEmojiRow({index, style, data, cursorRowIndex, curs
         <div
             style={style}
             className='emoji-picker__row'
+            role='row'
         >
             {row.items.map((emojiColumn) => {
                 const emoji = emojiColumn.item;

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_category_row.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_category_row.tsx
@@ -17,6 +17,7 @@ function EmojiPickerCategoryRow({categoryName, style}: Props) {
         <div
             className='emoji-picker-items__container'
             style={style}
+            role='row'
         >
             <div
                 className='emoji-picker__category-header'

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_current_results.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_current_results.tsx
@@ -91,7 +91,11 @@ const EmojiPickerCurrentResults = forwardRef<InfiniteLoader, Props>(({categoryOr
             className='emoji-picker__items'
             style={{height: EMOJI_CONTAINER_HEIGHT}}
         >
-            <div className='emoji-picker__container'>
+            <div
+                className='emoji-picker__container'
+                role='grid'
+                aria-labelledby='emojiPickerSearch'
+            >
                 <AutoSizer>
                     {({height, width}) => (
                         <InfiniteLoader

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_item.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_item.tsx
@@ -60,7 +60,7 @@ function EmojiPickerItem({emoji, rowIndex, isSelected, onClick, onMouseOver}: Pr
 
         content = (
             <img
-                alt={'emoji image'}
+                alt={`${emoji.name.toLocaleLowerCase()} emoji image`}
                 data-testid={emoji.short_names}
                 src={imgTrans}
                 className={`emojisprite emoji-category-${emoji.category} emoji-${emojiUnified}`}
@@ -74,7 +74,6 @@ function EmojiPickerItem({emoji, rowIndex, isSelected, onClick, onMouseOver}: Pr
                         emojiName: (emojiName).replace(/_/g, ' '),
                     },
                 )}
-                role='button'
             />
         );
     } else {
@@ -89,15 +88,17 @@ function EmojiPickerItem({emoji, rowIndex, isSelected, onClick, onMouseOver}: Pr
     }
 
     return (
-        <div
+        <button
             className={itemClassName}
             onClick={handleClick}
             onMouseOver={throttledMouseOver}
+            data-testid='emojiItem'
+            tabIndex={-1}
+            type='button'
+            aria-label={isSystemEmoji(emoji) ? emoji.short_name : emoji.name}
         >
-            <div data-testid='emojiItem'>
-                {content}
-            </div>
-        </div>
+            {content}
+        </button>
     );
 }
 

--- a/webapp/channels/src/sass/components/_emoticons.scss
+++ b/webapp/channels/src/sass/components/_emoticons.scss
@@ -538,7 +538,9 @@ $emoji-footer-height:  $emoji-footer-border-width + $emoji-half-height + $emoji-
     height: 36px;
     align-items: center;
     justify-content: center;
+    border:none;
     border-radius: 3px;
+    background-color: transparent;
     cursor: pointer;
     vertical-align: middle;
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fix the interactive controls that cannot be navigated to and operated with the keyboard alone in the Emoji picker modal

#### Steps to reproduce  

- Press Tab repeatedly to navigate through the Emoji button controls in the page.
- If the control can be focused, attempt to interact with the control using Enter, Space, Up/Down Arrow, and any other
applicable keystrokes.
- Notice that the control cannot be focused or that the control cannot be interacted with using the keyboard alone.

 #### Expected Behaviour
- The button should be focusable and operable by the keyboard.
- Element can be triggered when using the SPACE bar or ENTER key. 
- Element should have accessible name

<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If applicable, please include both or either of the following links:
Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes https://mattermost.atlassian.net/browse/MM-61577

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
For an easier comparison of UI changes a table (template below) can be used.
|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |
-->
![Screenshot (5)](https://github.com/user-attachments/assets/e0f3e522-6d6a-4c3d-bbd1-e950825f54cb)
![image](https://github.com/user-attachments/assets/01127916-cc4a-4266-9c27-c0654eec9123)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
