### PR TITLE
[MA-13]: Updated the Theme list section in the settings modal

### DIFF
--- a/webapp/channels/src/components/user_settings/display/user_settings_theme/custom_theme_chooser/__snapshots__/custom_theme_chooser.test.tsx.snap
+++ b/webapp/channels/src/components/user_settings/display/user_settings_theme/custom_theme_chooser/__snapshots__/custom_theme_chooser.test.tsx.snap
@@ -2,33 +2,43 @@
 
 exports[`components/user_settings/display/CustomThemeChooser should match, init 1`] = `
 <div
+  aria-labelledby="customThemes"
   className="appearance-section pt-2"
+  id="customThemesSection"
 >
   <div
     className="theme-elements row"
   >
-    <div
+    <h4
       className="theme-elements__header"
-      id="sidebarStyles"
-      onClick={[Function]}
     >
-      <MemoizedFormattedMessage
-        defaultMessage="Sidebar Styles"
-        id="user.settings.custom_theme.sidebarTitle"
-      />
-      <div
-        className="header__icon"
+      <button
+        aria-controls="sidebarStylesSection"
+        aria-expanded={false}
+        aria-label="Sidebar Styles"
+        id="sidebarStylesAccordion"
+        onClick={[Function]}
       >
-        <i
-          className="fa fa-plus"
+        <MemoizedFormattedMessage
+          defaultMessage="Sidebar Styles"
+          id="user.settings.custom_theme.sidebarTitle"
         />
-        <i
-          className="fa fa-minus"
-        />
-      </div>
-    </div>
+        <div
+          className="header__icon"
+        >
+          <i
+            className="fa fa-plus"
+          />
+          <i
+            className="fa fa-minus"
+          />
+        </div>
+      </button>
+    </h4>
     <div
+      aria-labelledby="sidebarStylesAccordion"
       className="theme-elements__body"
+      id="sidebarStylesSection"
     >
       <div
         className="col-sm-6 form-group element"
@@ -259,29 +269,36 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
   <div
     className="theme-elements row"
   >
-    <div
+    <h4
       className="theme-elements__header"
-      id="centerChannelStyles"
-      onClick={[Function]}
     >
-      <MemoizedFormattedMessage
-        defaultMessage="Center Channel Styles"
-        id="user.settings.custom_theme.centerChannelTitle"
-      />
-      <div
-        className="header__icon"
+      <button
+        aria-controls="centerChannelStylesSection"
+        aria-expanded={false}
+        aria-label="Center Channel Styles"
+        id="centerChannelStylesAccordion"
+        onClick={[Function]}
       >
-        <i
-          className="fa fa-plus"
+        <MemoizedFormattedMessage
+          defaultMessage="Center Channel Styles"
+          id="user.settings.custom_theme.centerChannelTitle"
         />
-        <i
-          className="fa fa-minus"
-        />
-      </div>
-    </div>
+        <div
+          className="header__icon"
+        >
+          <i
+            className="fa fa-plus"
+          />
+          <i
+            className="fa fa-minus"
+          />
+        </div>
+      </button>
+    </h4>
     <div
+      aria-labelledby="centerChannelStylesAccordion"
       className="theme-elements__body"
-      id="centerChannelStyles"
+      id="centerChannelStylesSection"
     >
       <div
         className="col-sm-6 form-group element"
@@ -457,28 +474,36 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
   <div
     className="theme-elements row"
   >
-    <div
+    <h4
       className="theme-elements__header"
-      id="linkAndButtonsStyles"
-      onClick={[Function]}
     >
-      <MemoizedFormattedMessage
-        defaultMessage="Link and Button Styles"
-        id="user.settings.custom_theme.linkButtonTitle"
-      />
-      <div
-        className="header__icon"
+      <button
+        aria-controls="linkAndButtonsStylesSection"
+        aria-expanded={false}
+        aria-label="Link and Button Styles"
+        id="linkAndButtonsStylesAccordion"
+        onClick={[Function]}
       >
-        <i
-          className="fa fa-plus"
+        <MemoizedFormattedMessage
+          defaultMessage="Link and Button Styles"
+          id="user.settings.custom_theme.linkButtonTitle"
         />
-        <i
-          className="fa fa-minus"
-        />
-      </div>
-    </div>
+        <div
+          className="header__icon"
+        >
+          <i
+            className="fa fa-plus"
+          />
+          <i
+            className="fa fa-minus"
+          />
+        </div>
+      </button>
+    </h4>
     <div
+      aria-labelledby="linkAndButtonsStylesAccordion"
       className="theme-elements__body"
+      id="linkAndButtonsStylesSection"
     >
       <div
         className="col-sm-6 form-group element"

--- a/webapp/channels/src/components/user_settings/display/user_settings_theme/custom_theme_chooser/custom_theme_chooser.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_theme/custom_theme_chooser/custom_theme_chooser.tsx
@@ -128,9 +128,9 @@ type State = {
 
 export class CustomThemeChooser extends React.PureComponent<Props, State> {
     textareaRef: RefObject<HTMLTextAreaElement>;
-    sidebarStylesHeaderRef: RefObject<HTMLDivElement>;
-    centerChannelStylesHeaderRef: RefObject<HTMLDivElement>;
-    linkAndButtonStylesHeaderRef: RefObject<HTMLDivElement>;
+    sidebarStylesHeaderRef: RefObject<HTMLButtonElement>;
+    centerChannelStylesHeaderRef: RefObject<HTMLButtonElement>;
+    linkAndButtonStylesHeaderRef: RefObject<HTMLButtonElement>;
     sidebarStylesRef: RefObject<HTMLDivElement>;
     centerChannelStylesRef: RefObject<HTMLDivElement>;
     linkAndButtonStylesRef: RefObject<HTMLDivElement>;
@@ -220,24 +220,33 @@ export class CustomThemeChooser extends React.PureComponent<Props, State> {
         this.textareaRef.current?.setSelectionRange(0, this.state.copyTheme.length);
     };
 
-    toggleSidebarStyles = (e: MouseEvent<HTMLDivElement>) => {
+    toggleSidebarStyles = (e: MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
 
         this.sidebarStylesHeaderRef.current?.classList.toggle('open');
+
+        const isAccordionOpen = this.sidebarStylesHeaderRef.current?.classList.contains('open');
+        this.sidebarStylesHeaderRef.current?.setAttribute('aria-expanded', `${isAccordionOpen}`);
         this.toggleSection(this.sidebarStylesRef.current);
     };
 
-    toggleCenterChannelStyles = (e: MouseEvent<HTMLDivElement>) => {
+    toggleCenterChannelStyles = (e: MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
 
         this.centerChannelStylesHeaderRef.current?.classList.toggle('open');
+
+        const isAccordionOpen = this.centerChannelStylesHeaderRef.current?.classList.contains('open');
+        this.centerChannelStylesHeaderRef.current?.setAttribute('aria-expanded', `${isAccordionOpen}`);
         this.toggleSection(this.centerChannelStylesRef.current);
     };
 
-    toggleLinkAndButtonStyles = (e: MouseEvent<HTMLDivElement>) => {
+    toggleLinkAndButtonStyles = (e: MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
 
         this.linkAndButtonStylesHeaderRef.current?.classList.toggle('open');
+
+        const isAccordionOpen = this.linkAndButtonStylesHeaderRef.current?.classList.contains('open');
+        this.linkAndButtonStylesHeaderRef.current?.setAttribute('aria-expanded', `${isAccordionOpen}`);
         this.toggleSection(this.linkAndButtonStylesRef.current);
     };
 
@@ -444,91 +453,112 @@ export class CustomThemeChooser extends React.PureComponent<Props, State> {
         );
 
         return (
-            <div className='appearance-section pt-2'>
+            <div
+                id='customThemesSection'
+                className='appearance-section pt-2'
+                aria-labelledby='customThemes'
+            >
                 <div className='theme-elements row'>
-                    <div
-                        ref={this.sidebarStylesHeaderRef}
-                        id='sidebarStyles'
-                        className='theme-elements__header'
-                        onClick={this.toggleSidebarStyles}
-                    >
-                        <FormattedMessage
-                            id='user.settings.custom_theme.sidebarTitle'
-                            defaultMessage='Sidebar Styles'
-                        />
-                        <div className='header__icon'>
-                            <i
-                                className='fa fa-plus'
-                                title={intl.formatMessage({id: 'generic_icons.expand', defaultMessage: 'Expand Icon'})}
+                    <h4 className='theme-elements__header'>
+                        <button
+                            ref={this.sidebarStylesHeaderRef}
+                            id='sidebarStylesAccordion'
+                            onClick={this.toggleSidebarStyles}
+                            aria-expanded={false}
+                            aria-controls='sidebarStylesSection'
+                            aria-label='Sidebar Styles'
+                        >
+                            <FormattedMessage
+                                id='user.settings.custom_theme.sidebarTitle'
+                                defaultMessage='Sidebar Styles'
                             />
-                            <i
-                                className='fa fa-minus'
-                                title={intl.formatMessage({id: 'generic_icons.collapse', defaultMessage: 'Collapse Icon'})}
-                            />
-                        </div>
-                    </div>
+                            <div className='header__icon'>
+                                <i
+                                    className='fa fa-plus'
+                                    title={intl.formatMessage({id: 'generic_icons.expand', defaultMessage: 'Expand Icon'})}
+                                />
+                                <i
+                                    className='fa fa-minus'
+                                    title={intl.formatMessage({id: 'generic_icons.collapse', defaultMessage: 'Collapse Icon'})}
+                                />
+                            </div>
+                        </button>
+                    </h4>
                     <div
                         ref={this.sidebarStylesRef}
+                        id='sidebarStylesSection'
+                        aria-labelledby='sidebarStylesAccordion'
                         className='theme-elements__body'
                     >
                         {sidebarElements}
                     </div>
                 </div>
                 <div className='theme-elements row'>
-                    <div
-                        ref={this.centerChannelStylesHeaderRef}
-                        id='centerChannelStyles'
-                        className='theme-elements__header'
-                        onClick={this.toggleCenterChannelStyles}
-                    >
-                        <FormattedMessage
-                            id='user.settings.custom_theme.centerChannelTitle'
-                            defaultMessage='Center Channel Styles'
-                        />
-                        <div className='header__icon'>
-                            <i
-                                className='fa fa-plus'
-                                title={intl.formatMessage({id: 'generic_icons.expand', defaultMessage: 'Expand Icon'})}
+                    <h4 className='theme-elements__header'>
+                        <button
+                            ref={this.centerChannelStylesHeaderRef}
+                            id='centerChannelStylesAccordion'
+                            onClick={this.toggleCenterChannelStyles}
+                            aria-expanded={false}
+                            aria-controls='centerChannelStylesSection'
+                            aria-label='Center Channel Styles'
+                        >
+                            <FormattedMessage
+                                id='user.settings.custom_theme.centerChannelTitle'
+                                defaultMessage='Center Channel Styles'
                             />
-                            <i
-                                className='fa fa-minus'
-                                title={intl.formatMessage({id: 'generic_icons.collapse', defaultMessage: 'Collapse Icon'})}
-                            />
-                        </div>
-                    </div>
+                            <div className='header__icon'>
+                                <i
+                                    className='fa fa-plus'
+                                    title={intl.formatMessage({id: 'generic_icons.expand', defaultMessage: 'Expand Icon'})}
+                                />
+                                <i
+                                    className='fa fa-minus'
+                                    title={intl.formatMessage({id: 'generic_icons.collapse', defaultMessage: 'Collapse Icon'})}
+                                />
+                            </div>
+                        </button>
+                    </h4>
                     <div
                         ref={this.centerChannelStylesRef}
-                        id='centerChannelStyles'
+                        id='centerChannelStylesSection'
                         className='theme-elements__body'
+                        aria-labelledby='centerChannelStylesAccordion'
                     >
                         {centerChannelElements}
                     </div>
                 </div>
                 <div className='theme-elements row'>
-                    <div
-                        ref={this.linkAndButtonStylesHeaderRef}
-                        id='linkAndButtonsStyles'
-                        className='theme-elements__header'
-                        onClick={this.toggleLinkAndButtonStyles}
-                    >
-                        <FormattedMessage
-                            id='user.settings.custom_theme.linkButtonTitle'
-                            defaultMessage='Link and Button Styles'
-                        />
-                        <div className='header__icon'>
-                            <i
-                                className='fa fa-plus'
-                                title={intl.formatMessage({id: 'generic_icons.expand', defaultMessage: 'Expand Icon'})}
+                    <h4 className='theme-elements__header'>
+                        <button
+                            ref={this.linkAndButtonStylesHeaderRef}
+                            id='linkAndButtonsStylesAccordion'
+                            onClick={this.toggleLinkAndButtonStyles}
+                            aria-expanded={false}
+                            aria-controls='linkAndButtonsStylesSection'
+                            aria-label='Link and Button Styles'
+                        >
+                            <FormattedMessage
+                                id='user.settings.custom_theme.linkButtonTitle'
+                                defaultMessage='Link and Button Styles'
                             />
-                            <i
-                                className='fa fa-minus'
-                                title={intl.formatMessage({id: 'generic_icons.collapse', defaultMessage: 'Collapse Icon'})}
-                            />
-                        </div>
-                    </div>
+                            <div className='header__icon'>
+                                <i
+                                    className='fa fa-plus'
+                                    title={intl.formatMessage({id: 'generic_icons.expand', defaultMessage: 'Expand Icon'})}
+                                />
+                                <i
+                                    className='fa fa-minus'
+                                    title={intl.formatMessage({id: 'generic_icons.collapse', defaultMessage: 'Collapse Icon'})}
+                                />
+                            </div>
+                        </button>
+                    </h4>
                     <div
+                        id='linkAndButtonsStylesSection'
                         ref={this.linkAndButtonStylesRef}
                         className='theme-elements__body'
+                        aria-labelledby='linkAndButtonsStylesAccordion'
                     >
                         {linkAndButtonElements}
                     </div>

--- a/webapp/channels/src/components/user_settings/display/user_settings_theme/premade_theme_chooser/premade_theme_chooser.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_theme/premade_theme_chooser/premade_theme_chooser.tsx
@@ -39,9 +39,9 @@ const PremadeThemeChooser = ({theme, updateTheme, allowedThemes = []}: Props) =>
                     className='col-xs-6 col-sm-3 premade-themes'
                     key={'premade-theme-key' + k}
                 >
-                    <div
+                    <button
                         id={`premadeTheme${premadeTheme.type?.replace(' ', '')}`}
-                        className={activeClass}
+                        className={`premadeThemeButton ${activeClass}`}
                         onClick={() => updateTheme(premadeTheme)}
                     >
                         <label>
@@ -61,14 +61,18 @@ const PremadeThemeChooser = ({theme, updateTheme, allowedThemes = []}: Props) =>
                             />
                             <div className='theme-label'>{toTitleCase(premadeTheme.type || '')}</div>
                         </label>
-                    </div>
+                    </button>
                 </div>,
             );
         }
     }
 
     return (
-        <div className='row appearance-section'>
+        <div
+            id='premadeThemesSection'
+            className='row appearance-section'
+            aria-labelledby='standardThemes'
+        >
             <div className='clearfix'>
                 {premadeThemes}
             </div>

--- a/webapp/channels/src/components/user_settings/display/user_settings_theme/user_settings_theme.tsx
+++ b/webapp/channels/src/components/user_settings/display/user_settings_theme/user_settings_theme.tsx
@@ -184,17 +184,23 @@ export default class ThemeSetting extends React.PureComponent<Props, State> {
 
             if (this.props.allowCustomThemes) {
                 inputs.push(
-                    <div
+                    <button
+                        id='standardThemes'
                         className='radio'
                         key='premadeThemeColorLabel'
+                        onClick={this.updateType.bind(this, 'premade')}
+                        aria-expanded={!displayCustom}
+                        role='radio'
+                        aria-checked={!displayCustom}
+                        aria-controls='premadeThemesSection'
                     >
                         <label>
                             <input
-                                id='standardThemes'
                                 type='radio'
                                 name='theme'
                                 checked={!displayCustom}
-                                onChange={this.updateType.bind(this, 'premade')}
+                                tabIndex={-1}
+                                readOnly={true} // the button will help the assistive technology to announce the content and preferred ARIA-properties, hence added `readonly` to avoid redundant speaking of content.
                             />
                             <FormattedMessage
                                 id='user.settings.display.theme.themeColors'
@@ -202,7 +208,7 @@ export default class ThemeSetting extends React.PureComponent<Props, State> {
                             />
                         </label>
                         <br/>
-                    </div>,
+                    </button>,
                 );
             }
 
@@ -210,24 +216,30 @@ export default class ThemeSetting extends React.PureComponent<Props, State> {
 
             if (this.props.allowCustomThemes) {
                 inputs.push(
-                    <div
+                    <button
+                        id='customThemes'
                         className='radio'
                         key='customThemeColorLabel'
+                        onClick={this.updateType.bind(this, 'custom')}
+                        aria-expanded={displayCustom}
+                        aria-checked={displayCustom}
+                        aria-controls='customThemesSection'
+                        role='radio'
                     >
                         <label>
                             <input
-                                id='customThemes'
                                 type='radio'
                                 name='theme'
                                 checked={displayCustom}
-                                onChange={this.updateType.bind(this, 'custom')}
+                                tabIndex={-1}
+                                readOnly={true} // the button will help the assistive technology to announce the content and preferred ARIA-properties, hence added `readonly` to avoid redundant speaking of content.
                             />
                             <FormattedMessage
                                 id='user.settings.display.theme.customTheme'
                                 defaultMessage='Custom Theme'
                             />
                         </label>
-                    </div>,
+                    </button>,
                 );
 
                 inputs.push(custom);

--- a/webapp/channels/src/sass/routes/_settings.scss
+++ b/webapp/channels/src/sass/routes/_settings.scss
@@ -371,6 +371,11 @@
                             white-space: nowrap;
                         }
 
+                        .premadeThemeButton{
+                            border: none;
+                            background: none;
+                        }
+
                         label {
                             width: 100%;
                         }
@@ -407,12 +412,21 @@
                     }
 
                     .theme-elements__header {
-                        padding: 1px 0 10px;
                         border-bottom: 1px solid;
                         margin: 10px 20px 0 0;
                         cursor: pointer;
                         font-size: functions.em(13.5px);
                         font-weight: 600;
+
+                        button {
+                            display: flex;
+                            width: 100%;
+                            align-items: center;
+                            justify-content: space-between;
+                            padding: 10px 1px;
+                            border: none;
+                            background: none;
+                        }
 
                         .fa-minus {
                             display: none;
@@ -442,6 +456,7 @@
                         background-color: rgba(255, 255, 255, 0.05);
                         overflow-y: hidden;
                         transition: all 0.4s ease-out;
+                        visibility: hidden;
 
                         @include mixins.pie-clearfix;
 
@@ -449,6 +464,7 @@
                             max-height: 1200px;
                             padding: 24px 0 0 24px;
                             margin: 0 20px 0 0;
+                            visibility: visible;
                         }
                     }
 
@@ -499,6 +515,12 @@
                     list-style-type: none;
 
                     .radio {
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        padding: 0;
+                        border:none;
+                        background: none;
                         p {
                             padding-top: 5px;
                             padding-left: 20px;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- Updated the premade theme and custom theme radio button accordion.
- Replaced divs with buttons to ensure keyboard navigation for the premade themes.
- Updated the accordion in custom theme section and added aria-expanded and aria-controls attributes.

#### Steps to reproduce  
- Navigate to the the Display tab control using down arrow key.
- Now navigate to the Theme edit button and select it.
- Now navigate to the Custom Theme radio button using arrow keys.
- Now navigate to the Sidebar Styles button and notice that the control is not reachable by the keyboard.

#### Expected Behavior 
- The premade theme and custom theme radio button accordion must be keyboard accessible as well its content.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Jira https://mattermost.atlassian.net/browse/MM-61592

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

<table>
    <tr>
        <th>Before</th>
 <th>After</th>
    </tr>
    <tr>
        <td>
 <img src="https://github.com/user-attachments/assets/2c1330b9-c710-4e9b-b83c-01d2f5f908c4">
</td>
  <td>
 <img src="https://github.com/user-attachments/assets/045a646e-1a05-4adc-bcf8-44ad64fa4430">
</td>
    </tr>
</table>

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
