### PR TITLE
[MA-30]: MM-61604: Provide proper name, role, and state information to skin tone accordion

### DIFF
--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_skin.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_skin.tsx
@@ -131,6 +131,7 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
                     onClick={() => this.hideSkinTonePicker(skin)}
                 >
                     <img
+                        alt={skinTone.label.defaultMessage}
                         src={imgTrans}
                         className={spriteClassName}
                     />
@@ -144,6 +145,8 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
                         className='skin-tones__close-icon style--none'
                         onClick={() => this.hideSkinTonePicker(this.props.userSkinTone)}
                         aria-label={closeButtonLabel}
+                        aria-expanded={this.state.pickerExtended}
+                        tabIndex={0}
                     >
                         <CloseIcon
                             size={16}
@@ -182,6 +185,7 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
                     className='style--none skin-tones__icon skin-tones__expand-icon'
                     onClick={this.showSkinTonePicker}
                     aria-label={expandButtonLabel}
+                    aria-controls='skin-tones-content'
                 >
                     <img
                         alt={'emoji skin tone picker'}
@@ -201,8 +205,13 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
                 timeout={200}
             >
                 <div className={classNames('skin-tones', {'skin-tones--active': this.state.pickerExtended})}>
-                    <div className={classNames('skin-tones__content', {'skin-tones__content__single': !this.state.pickerExtended})}>
-                        {this.state.pickerExtended ? this.extended() : this.collapsed()}
+                    <div
+                        id='skin-tones-content'
+                        className={classNames('skin-tones__content', {'skin-tones__content__single': !this.state.pickerExtended})}
+                        aria-orientation='horizontal'
+                        aria-expanded={this.state.pickerExtended}
+                    >
+                        {this.state.pickerExtended ? this.extended() : this.collapsed() }
                     </div>
                 </div>
             </CSSTransition>

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_skin.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_skin.tsx
@@ -147,6 +147,7 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
                         aria-label={closeButtonLabel}
                         aria-expanded={this.state.pickerExtended}
                         tabIndex={0}
+                        aria-controls='skin-tones-icons'
                     >
                         <CloseIcon
                             size={16}
@@ -159,7 +160,12 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
                         />
                     </div>
                 </div>
-                <div className='skin-tones__icons'>
+                <div
+                    className='skin-tones__icons'
+                    id='skin-tones-icons'
+                    aria-label='Skin tone icons'
+                    role='region'
+                >
                     {choices}
                 </div>
             </>
@@ -185,7 +191,8 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
                     className='style--none skin-tones__icon skin-tones__expand-icon'
                     onClick={this.showSkinTonePicker}
                     aria-label={expandButtonLabel}
-                    aria-controls='skin-tones-content'
+                    aria-controls='skin-tones-icons'
+                    aria-expanded={this.state.pickerExtended}
                 >
                     <img
                         alt={'emoji skin tone picker'}
@@ -209,7 +216,6 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
                         id='skin-tones-content'
                         className={classNames('skin-tones__content', {'skin-tones__content__single': !this.state.pickerExtended})}
                         aria-orientation='horizontal'
-                        aria-expanded={this.state.pickerExtended}
                     >
                         {this.state.pickerExtended ? this.extended() : this.collapsed() }
                     </div>

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_skin.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_skin.tsx
@@ -213,7 +213,6 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
             >
                 <div className={classNames('skin-tones', {'skin-tones--active': this.state.pickerExtended})}>
                     <div
-                        id='skin-tones-content'
                         className={classNames('skin-tones__content', {'skin-tones__content__single': !this.state.pickerExtended})}
                         aria-orientation='horizontal'
                     >


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
There are accordions without appropriate state information like Skin tone button. This PR adds appropriate role, state information to it.

#### Steps to reproduce  
- Navigate to the Skin tone button.
- Inspect its element with Chrome DevTools.
- Review its nesting structure.
- In the Accessibility tab, expand the Computed Properties section.
- Review the values for and "Expanded".

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes: https://mattermost.atlassian.net/browse/MM-61604

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->
![Screenshot from 2024-12-18 12-08-35](https://github.com/user-attachments/assets/40924e08-4897-4bd3-af68-6c0d0d231461)
![image](https://github.com/user-attachments/assets/95938156-398b-48ea-a338-95258edf87a5)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
