### PR TITLE
[MA-22]: Added aria-live property for message sent status

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -192,6 +192,7 @@ const AdvancedTextEditor = ({
     const draftRef = useRef(draftFromStore);
     const storedDrafts = useRef<Record<string, PostDraft | undefined>>({});
     const lastBlurAt = useRef(0);
+    const messageStatusRef = useRef<HTMLDivElement | null>(null);
 
     const [draft, setDraft] = useState(draftFromStore);
     const [caretPosition, setCaretPosition] = useState(draft.message.length);
@@ -346,12 +347,12 @@ const AdvancedTextEditor = ({
     const onSubmit = useCallback((submittingDraft?: PostDraft, schedulingInfo?: SchedulingInfo, options?: CreatePostOptions) => {
         handleSubmit(submittingDraft, schedulingInfo, options);
         if (!errorClass) {
-            const messageStatusElement = document.getElementById('sentMessageStatus');
-            const messageStatusInnerText = messageStatusElement?.innerText;
+            const messageStatusElement = messageStatusRef.current;
+            const messageStatusInnerText = messageStatusElement?.textContent;
             if (messageStatusInnerText === 'Message Sent') {
-                messageStatusElement!.innerHTML = 'Message Sent &nbsp;';
+                messageStatusElement!.textContent = 'Message Sent &nbsp;';
             } else {
-                messageStatusElement!.innerText = 'Message Sent';
+                messageStatusElement!.textContent = 'Message Sent';
             }
         }
     }, [errorClass, handleSubmit]);
@@ -854,13 +855,10 @@ const AdvancedTextEditor = ({
                 isInEditMode={isInEditMode}
             />
             <div
-                id='sentMessageStatus'
+                ref={messageStatusRef}
                 aria-live='assertive'
-                style={{
-                    position: 'absolute',
-                    top: '-1000px',
-                }}
-            >{ }</div>
+                className='sr-only'
+            />
         </form>
     );
 };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- Added aria-live property to the message status element.
- Programmatically triggering the `Message Sent` prompt.

#### Steps to reproduce  
- Navigate to the write to town square edit field and type 'tester'.
- Now navigate to the Send a message button and select it.
- Notice that after selecting the Send a message button, the screen reader not announcing any status message.

#### Expected Behavior 
- When the message is successfully sent a screen should announce the status of sent message.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->
Jira https://mattermost.atlassian.net/browse/MM-61619

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

<table>
    <tr>
        <th>Before</th>
 <th>After</th>
    </tr>
    <tr>
        <td>
 <img src="https://github.com/user-attachments/assets/4122f9bc-c2cc-4a76-b3eb-b0044ef32d78">
</td>
  <td>
 <img src="https://github.com/user-attachments/assets/df3efa9b-1416-4175-afff-792dc6ffb4e9">
</td>
    </tr>
</table>

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
