### PR TITLE
MM-61641: Ensure implicit list markup is avoided

### DIFF
--- a/webapp/channels/src/components/post/post_options.tsx
+++ b/webapp/channels/src/components/post/post_options.tsx
@@ -120,12 +120,12 @@ const PostOptions = (props: Props): JSX.Element => {
     let commentIcon;
     if (showCommentIcon) {
         commentIcon = (
-            <li key="commentIcon__listItem">
-            <CommentIcon
-                handleCommentClick={props.handleCommentClick}
-                postId={post.id}
-                extraClass={commentIconExtraClass}
-                commentCount={props.collapsedThreadsEnabled ? 0 : props.replyCount}
+            <li key='commentIcon__listItem'>
+                <CommentIcon
+                    handleCommentClick={props.handleCommentClick}
+                    postId={post.id}
+                    extraClass={commentIconExtraClass}
+                    commentCount={props.collapsedThreadsEnabled ? 0 : props.replyCount}
                 />
             </li>
         );
@@ -146,7 +146,7 @@ const PostOptions = (props: Props): JSX.Element => {
                 teamId={props.teamId}
                 emojis={props.recentEmojis}
                 size={showMoreReactions ? 3 : 1}
-                />
+            />
         );
     }
 
@@ -154,15 +154,15 @@ const PostOptions = (props: Props): JSX.Element => {
     let postReaction;
     if (showReactionIcon) {
         postReaction = (
-            <li key="postReaction__listItem">
-            <PostReaction
-                channelId={post.channel_id}
-                location={props.location}
-                postId={post.id}
-                teamId={props.teamId}
-                getDotMenuRef={getDotMenuRef}
-                showEmojiPicker={showEmojiPicker}
-                toggleEmojiPicker={toggleEmojiPicker}
+            <li key='postReaction__listItem'>
+                <PostReaction
+                    channelId={post.channel_id}
+                    location={props.location}
+                    postId={post.id}
+                    teamId={props.teamId}
+                    getDotMenuRef={getDotMenuRef}
+                    showEmojiPicker={showEmojiPicker}
+                    toggleEmojiPicker={toggleEmojiPicker}
                 />
             </li>
         );
@@ -171,11 +171,11 @@ const PostOptions = (props: Props): JSX.Element => {
     let flagIcon: ReactNode = null;
     if (!isMobileView && (!isEphemeral && !post.failed && !systemMessage)) {
         flagIcon = (
-            <li key="flagIcon__listItem">
-             <PostFlagIcon
-                location={props.location}
-                postId={post.id}
-                isFlagged={props.isFlagged}
+            <li key='flagIcon__listItem'>
+                <PostFlagIcon
+                    location={props.location}
+                    postId={post.id}
+                    isFlagged={props.isFlagged}
                 />
             </li>
         );
@@ -184,12 +184,12 @@ const PostOptions = (props: Props): JSX.Element => {
     // Action menus
     const showActionsMenuIcon = props.shouldShowActionsMenu && (isMobileView || hoverLocal);
     const actionsMenu = showActionsMenuIcon && (
-        <li key="actionsMenu__listItem">
-        <ActionsMenu
-            post={post}
-            location={props.location}
-            handleDropdownOpened={handleActionsMenuOpened}
-            isMenuOpen={showActionsMenu}
+        <li key='actionsMenu__listItem'>
+            <ActionsMenu
+                post={post}
+                location={props.location}
+                handleDropdownOpened={handleActionsMenuOpened}
+                isMenuOpen={showActionsMenu}
             />
         </li>
     );
@@ -202,8 +202,8 @@ const PostOptions = (props: Props): JSX.Element => {
                     const Component = item.component as any;
                     return (
                         <li key={item.id}>
-                        <Component
-                            post={props.post}
+                            <Component
+                                post={props.post}
                             />
                         </li>
                     );
@@ -213,17 +213,17 @@ const PostOptions = (props: Props): JSX.Element => {
     }
 
     const dotMenu = (
-        <li key="dotMenu__listItem">
-        <DotMenu
-            post={props.post}
-            location={props.location}
-            isFlagged={props.isFlagged}
-            handleDropdownOpened={handleDotMenuOpened}
-            handleCommentClick={props.handleCommentClick}
-            handleAddReactionClick={toggleEmojiPicker}
-            isReadOnly={isReadOnly || channelIsArchived}
-            isMenuOpen={showDotMenu}
-            enableEmojiPicker={props.enableEmojiPicker}
+        <li key='dotMenu__listItem'>
+            <DotMenu
+                post={props.post}
+                location={props.location}
+                isFlagged={props.isFlagged}
+                handleDropdownOpened={handleDotMenuOpened}
+                handleCommentClick={props.handleCommentClick}
+                handleAddReactionClick={toggleEmojiPicker}
+                isReadOnly={isReadOnly || channelIsArchived}
+                isMenuOpen={showDotMenu}
+                enableEmojiPicker={props.enableEmojiPicker}
             />
         </li>
     );
@@ -250,7 +250,7 @@ const PostOptions = (props: Props): JSX.Element => {
                 {dotMenu}
                 {flagIcon}
                 {props.canReply && !hasCRTFooter &&
-                  <li key="commentIcon__listItem">
+                <li key='commentIcon__listItem'>
                     <CommentIcon
                         location={props.location}
                         handleCommentClick={props.handleCommentClick}
@@ -258,20 +258,20 @@ const PostOptions = (props: Props): JSX.Element => {
                         postId={post.id}
                         searchStyle={'search-item__comment'}
                         extraClass={props.replyCount ? 'icon--visible' : ''}
-                        />
-                   </li>
+                    />
+                </li>
                 }
-                <li key="searchItem__listItem">
-                <a
-                    href='#'
-                    onClick={props.handleJumpClick}
-                    className='search-item__jump'
+                <li key='searchItem__listItem'>
+                    <a
+                        href='#'
+                        onClick={props.handleJumpClick}
+                        className='search-item__jump'
                     >
-                    <FormattedMessage
-                        id='search_item.jump'
-                        defaultMessage='Jump'
+                        <FormattedMessage
+                            id='search_item.jump'
+                            defaultMessage='Jump'
                         />
-                </a>
+                    </a>
                 </li>
             </ul>
         );

--- a/webapp/channels/src/components/post/post_options.tsx
+++ b/webapp/channels/src/components/post/post_options.tsx
@@ -59,7 +59,7 @@ type Props = {
 };
 
 const PostOptions = (props: Props): JSX.Element => {
-    const dotMenuRef = useRef<HTMLDivElement>(null);
+    const dotMenuRef = useRef<HTMLUListElement>(null);
 
     const [showEmojiPicker, setShowEmojiPicker] = useState(false);
     const [showDotMenu, setShowDotMenu] = useState(false);
@@ -120,12 +120,14 @@ const PostOptions = (props: Props): JSX.Element => {
     let commentIcon;
     if (showCommentIcon) {
         commentIcon = (
+            <li key="commentIcon__listItem">
             <CommentIcon
                 handleCommentClick={props.handleCommentClick}
                 postId={post.id}
                 extraClass={commentIconExtraClass}
                 commentCount={props.collapsedThreadsEnabled ? 0 : props.replyCount}
-            />
+                />
+            </li>
         );
     }
 
@@ -144,7 +146,7 @@ const PostOptions = (props: Props): JSX.Element => {
                 teamId={props.teamId}
                 emojis={props.recentEmojis}
                 size={showMoreReactions ? 3 : 1}
-            />
+                />
         );
     }
 
@@ -152,6 +154,7 @@ const PostOptions = (props: Props): JSX.Element => {
     let postReaction;
     if (showReactionIcon) {
         postReaction = (
+            <li key="postReaction__listItem">
             <PostReaction
                 channelId={post.channel_id}
                 location={props.location}
@@ -160,30 +163,35 @@ const PostOptions = (props: Props): JSX.Element => {
                 getDotMenuRef={getDotMenuRef}
                 showEmojiPicker={showEmojiPicker}
                 toggleEmojiPicker={toggleEmojiPicker}
-            />
+                />
+            </li>
         );
     }
 
     let flagIcon: ReactNode = null;
     if (!isMobileView && (!isEphemeral && !post.failed && !systemMessage)) {
         flagIcon = (
-            <PostFlagIcon
+            <li key="flagIcon__listItem">
+             <PostFlagIcon
                 location={props.location}
                 postId={post.id}
                 isFlagged={props.isFlagged}
-            />
+                />
+            </li>
         );
     }
 
     // Action menus
     const showActionsMenuIcon = props.shouldShowActionsMenu && (isMobileView || hoverLocal);
     const actionsMenu = showActionsMenuIcon && (
+        <li key="actionsMenu__listItem">
         <ActionsMenu
             post={post}
             location={props.location}
             handleDropdownOpened={handleActionsMenuOpened}
             isMenuOpen={showActionsMenu}
-        />
+            />
+        </li>
     );
 
     let pluginItems: ReactNode = null;
@@ -193,10 +201,11 @@ const PostOptions = (props: Props): JSX.Element => {
                 if (item.component) {
                     const Component = item.component as any;
                     return (
+                        <li key={item.id}>
                         <Component
                             post={props.post}
-                            key={item.id}
-                        />
+                            />
+                        </li>
                     );
                 }
                 return null;
@@ -204,6 +213,7 @@ const PostOptions = (props: Props): JSX.Element => {
     }
 
     const dotMenu = (
+        <li key="dotMenu__listItem">
         <DotMenu
             post={props.post}
             location={props.location}
@@ -214,7 +224,8 @@ const PostOptions = (props: Props): JSX.Element => {
             isReadOnly={isReadOnly || channelIsArchived}
             isMenuOpen={showDotMenu}
             enableEmojiPicker={props.enableEmojiPicker}
-        />
+            />
+        </li>
     );
 
     // Build post options
@@ -235,10 +246,11 @@ const PostOptions = (props: Props): JSX.Element => {
     } else if (props.location === Locations.SEARCH) {
         const hasCRTFooter = props.collapsedThreadsEnabled && !post.root_id && (post.reply_count > 0 || post.is_following);
         options = (
-            <div className='col__controls post-menu'>
+            <ul className='col__controls post-menu'>
                 {dotMenu}
                 {flagIcon}
                 {props.canReply && !hasCRTFooter &&
+                  <li key="commentIcon__listItem">
                     <CommentIcon
                         location={props.location}
                         handleCommentClick={props.handleCommentClick}
@@ -246,23 +258,26 @@ const PostOptions = (props: Props): JSX.Element => {
                         postId={post.id}
                         searchStyle={'search-item__comment'}
                         extraClass={props.replyCount ? 'icon--visible' : ''}
-                    />
+                        />
+                   </li>
                 }
+                <li key="searchItem__listItem">
                 <a
                     href='#'
                     onClick={props.handleJumpClick}
                     className='search-item__jump'
-                >
+                    >
                     <FormattedMessage
                         id='search_item.jump'
                         defaultMessage='Jump'
-                    />
+                        />
                 </a>
-            </div>
+                </li>
+            </ul>
         );
     } else if (!props.isPostBeingEdited) {
         options = (
-            <div
+            <ul
                 ref={dotMenuRef}
                 data-testid={`post-menu-${props.post.id}`}
                 className={classnames('col post-menu', {'post-menu--position': !hoverLocal && showCommentIcon})}
@@ -275,7 +290,7 @@ const PostOptions = (props: Props): JSX.Element => {
                 {actionsMenu}
                 {commentIcon}
                 {(collapsedThreadsEnabled || showRecentlyUsedReactions) && dotMenu}
-            </div>
+            </ul>
         );
     }
 

--- a/webapp/channels/src/components/post_view/post_reaction/post_reaction.tsx
+++ b/webapp/channels/src/components/post_view/post_reaction/post_reaction.tsx
@@ -31,7 +31,7 @@ export type Props = WrappedComponentProps & {
     channelId?: string;
     postId: string;
     teamId: string;
-    getDotMenuRef: () => HTMLDivElement | null;
+    getDotMenuRef: () => HTMLUListElement | null;
     location?: keyof typeof Locations;
     showEmojiPicker: boolean;
     toggleEmojiPicker: (e?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;

--- a/webapp/channels/src/components/post_view/post_recent_reactions/post_recent_reactions.tsx
+++ b/webapp/channels/src/components/post_view/post_recent_reactions/post_recent_reactions.tsx
@@ -96,13 +96,13 @@ export default class PostRecentReactions extends React.PureComponent<Props, Stat
                     emoji={getEmojiName(emoji)}
                     isEmojiLarge={true}
                 >
-                    <div>
+                    <li>
                         <EmojiItem
                             emoji={emoji}
                             onItemClick={this.handleToggleEmoji}
                             order={n}
                         />
-                    </div>
+                    </li>
                 </WithTooltip>
             </ChannelPermissionGate>
         ),

--- a/webapp/channels/src/sass/components/_post-menu.scss
+++ b/webapp/channels/src/sass/components/_post-menu.scss
@@ -12,6 +12,7 @@
     border: 1px solid transparent;
     border-radius: 4px;
     white-space: normal;
+    list-style: none;
 }
 
 .post-menu__item {

--- a/webapp/channels/src/sass/components/_post-menu.scss
+++ b/webapp/channels/src/sass/components/_post-menu.scss
@@ -11,8 +11,8 @@
     padding: 4px;
     border: 1px solid transparent;
     border-radius: 4px;
-    white-space: normal;
     list-style: none;
+    white-space: normal;
 }
 
 .post-menu__item {


### PR DESCRIPTION
#### Summary
There is content that appears as a list but does not use list markup. Examples include: 
-White check mark, +1, Grinning, Add reaction, save message, Message actions, Reply and More buttons list


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61641

#### Screenshots

|  before  |  after  |
|----|----|
| ![image](https://github.com/user-attachments/assets/1eaf499d-d2d0-4bce-9038-4fad7fd7ad1f) | <insert after screenshot here> 
![image](https://github.com/user-attachments/assets/5045855f-caa0-4d25-8697-5b9af2dc35a0) |

#### Release Note

```release-note
NONE
```
