### PR TITLE
MM-61616: Add tab roles inside Emoji Picker

### DIFF
--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_categories.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_categories.tsx
@@ -70,6 +70,7 @@ function EmojiPickerCategories({
             id='emojiPickerCategories'
             className='emoji-picker__categories'
             onKeyDown={handleKeyDown}
+            role='tablist'
         >
             {categoryNames.map((categoryName) => {
                 const category = categories[categoryName];

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_category.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_category.tsx
@@ -42,14 +42,17 @@ function EmojiPickerCategory({category, categoryRowIndex, selected, enable, onCl
                 <FormattedMessage {...category.label}/>
             }
         >
-            <a
-                className={className}
-                href='#'
+            <button
+                role='tab'
+                aria-selected={selected}
+                className={classNames('style--none', className)}
+                id={`emojiPickerCategoryTab-${category.name}`}
                 onClick={handleClick}
+                aria-controls={`emojipickercat-${category.name}`}
                 aria-label={intl.formatMessage(category.label)}
             >
                 <i className={category.iconClassName}/>
-            </a>
+            </button>
         </WithTooltip>
     );
 }

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_category_row.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_category_row.tsx
@@ -21,6 +21,8 @@ function EmojiPickerCategoryRow({categoryName, style}: Props) {
             <div
                 className='emoji-picker__category-header'
                 id={`emojipickercat-${categoryName}`}
+                aria-labelledby={`emojiPickerCategoryTab-${categoryName}`}
+                role='tabpanel'
             >
                 <FormattedMessage id={`emoji_picker.${categoryName}`}/>
             </div>


### PR DESCRIPTION
#### Summary
There are tabs without appropriate role, and state information. Examples include: 
-Recently Used, Smileys & Emotion, People & Body, Animals & Nature, Food & Drink, Travel Places, Activities, Objects, Symbols, Flags and Custom tab controls

Steps to reproduce  

Navigate to Recently Used, Smileys & Emotion, People & Body, Animals & Nature, Food & Drink, Travel Places, Activities, Objects, Symbols, Flags and Custom tab controls.

Inspect the element.

Notice that the Recently Used, Smileys & Emotion, People & Body, Animals & Nature, Food & Drink, Travel Places, Activities, Objects, Symbols, Flags and Custom tab controls are incorrectly coded as a link.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61616

#### Screenshots


|  before  |  after  |
|----|----|
| 
![image](https://github.com/user-attachments/assets/a6c45156-d0f3-4ae6-b3ad-fdb036238ec0) | 
![image](https://github.com/user-attachments/assets/834f66e7-36b1-4746-a445-48e40d0a7bb4)
|


#### Release Note
```release-note
NONE
```