### PR TITLE
MM-61640: Add described by prop to notifications settings

### DIFF
--- a/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
@@ -597,7 +597,8 @@ class NotificationsTab extends React.PureComponent<Props, State> {
                             Menu: () => null,
                             MenuList: () => null,
                         }}
-                        aria-labelledby='notificationTriggerCustom'
+                        aria-labelledby='settingTitle'
+                        aria-describedby='extraInfo'
                         onChange={this.handleChangeForCustomKeysWithNotificationInput}
                         value={this.state.customKeysWithNotification}
                         inputValue={this.state.customKeysWithNotificationInputValue}


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

The Keywords that trigger notifications edit field  label is not descriptive and also additional information is not associated with the edit field.

#### Steps to reproduce  

- Navigate to the Keywords that trigger notifications edit button and select it.
- Now navigate to the Keywords that trigger notifications edit field.
- Notice that the label is not descriptive for the edit field and and also additional information is not associated with the edit field.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

https://mattermost.atlassian.net/browse/MM-61685

#### Screenshots
|  before  |  after  |
|----|----|
| https://mattermost.atlassian.net/browse/MM-61685 | ![image](https://github.com/user-attachments/assets/b9b9536b-12eb-44f7-8929-8ed89cf4a570) |


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
